### PR TITLE
Added support for XML

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,12 @@
 source 'https://rubygems.org'
 
+gem 'activesupport', '~> 4.1.0'
 gem 'barby'
+gem 'builder', '~> 3.2.2'
 gem 'rmagick', '2.13.2', require: false
 gem 'rqrcode'
-gem 'sinatra'
+gem 'sinatra', '~> 1.4.5'
+gem 'sinatra-contrib', '~> 1.4.2'
 
 group :development, :test do
   gem 'icepick', '~> 1.1.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,18 @@
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (4.1.0)
+      i18n (~> 0.6, >= 0.6.9)
+      json (~> 1.7, >= 1.7.7)
+      minitest (~> 5.1)
+      thread_safe (~> 0.1)
+      tzinfo (~> 1.1)
     awesome_print (1.2.0)
+    backports (3.6.0)
     barby (0.5.1)
     binding_of_caller (0.7.2)
       debug_inspector (>= 0.0.1)
+    builder (3.2.2)
     byebug (2.7.0)
       columnize (~> 0.3)
       debugger-linecache (~> 1.2)
@@ -21,6 +29,7 @@ GEM
     debugger-linecache (1.2.0)
     diff-lcs (1.2.5)
     docile (1.1.3)
+    i18n (0.6.9)
     icepick (1.1.1)
       awesome_print (~> 1.2)
       colorize (~> 0.7.2)
@@ -28,8 +37,10 @@ GEM
       pry-byebug (~> 1.3.2)
       pry-doc (~> 0.6.0)
       pry-stack_explorer (~> 0.4.9)
+    json (1.8.1)
     method_source (0.8.2)
     mime-types (2.2)
+    minitest (5.3.3)
     multi_json (1.9.2)
     pry (0.9.12.6)
       coderay (~> 1.0)
@@ -72,19 +83,31 @@ GEM
       rack (~> 1.4)
       rack-protection (~> 1.4)
       tilt (~> 1.3, >= 1.3.4)
+    sinatra-contrib (1.4.2)
+      backports (>= 2.0)
+      multi_json
+      rack-protection
+      rack-test
+      sinatra (~> 1.4.0)
+      tilt (~> 1.3)
     slop (3.5.0)
     term-ansicolor (1.3.0)
       tins (~> 1.0)
     thor (0.19.1)
+    thread_safe (0.3.3)
     tilt (1.4.1)
     tins (1.1.0)
+    tzinfo (1.1.0)
+      thread_safe (~> 0.1)
     yard (0.8.7.4)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  activesupport (~> 4.1.0)
   barby
+  builder (~> 3.2.2)
   coveralls
   icepick (~> 1.1.1)
   rack-test
@@ -94,4 +117,5 @@ DEPENDENCIES
   rr
   rspec
   simplecov (~> 0.7)
-  sinatra
+  sinatra (~> 1.4.5)
+  sinatra-contrib (~> 1.4.2)

--- a/barcoded.rb
+++ b/barcoded.rb
@@ -1,6 +1,7 @@
 class Barcoded < Sinatra::Base
   helpers Sinatra::RequestHelpers
   helpers Sinatra::ResponseHelpers
+  register Sinatra::RespondWith
   include Sinatra::ExceptionHandler
 
   enable :logging

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,6 +1,9 @@
+require 'active_support'
+require 'active_support/core_ext/hash/conversions'
 require 'bundler/setup'
 require 'json'
 require 'sinatra/base'
+require 'sinatra/contrib'
 
 ENV['RACK_ENV'] ||= 'development'
 

--- a/lib/sinatra/request_helpers.rb
+++ b/lib/sinatra/request_helpers.rb
@@ -24,8 +24,11 @@ module Sinatra
     def normalize_params!
       case request.env['CONTENT_TYPE']
       when 'application/json'
-        json_body = JSON.parse(request.env['rack.input'].read)
+        json_body = ::JSON.parse(request.env['rack.input'].read)
         params.merge!(json_body)
+      when 'application/xml', 'text/xml'
+        xml_body = Hash.from_xml(request.env['rack.input'].read)
+        params.merge!(xml_body['barcode'])
       end
     end
 
@@ -61,4 +64,3 @@ module Sinatra
 
   helpers RequestHelpers
 end
-

--- a/spec/barcoded_spec.rb
+++ b/spec/barcoded_spec.rb
@@ -7,7 +7,7 @@ describe Barcoded do
       let(:format)   { 'png' }
       let(:data)     { '123ABC' }
 
-      let(:headers) { { 'CONTENT_TYPE' => content_type } }
+      let(:headers) { { 'CONTENT_TYPE' => content_type, 'HTTP_ACCEPT' => accept } }
 
       context 'with unsupported format' do
         let(:format) { 'jar' }
@@ -15,7 +15,7 @@ describe Barcoded do
         it 'will return 415 Unsupported Media Type' do
           post '/barcodes', barcode_request, headers
           expect(last_response.status).to eq 415
-          expect(json_response['error']).to eq Barcoded::UNSUPPORTED_FORMAT
+          expect(response['error']).to eq Barcoded::UNSUPPORTED_FORMAT
         end
       end
 
@@ -25,7 +25,7 @@ describe Barcoded do
         it 'will return 415 Unsupported Media Type' do
           post '/barcodes', barcode_request, headers
           expect(last_response.status).to eq 415
-          expect(json_response['error']).to eq Barcoded::UNSUPPORTED_ENCODING
+          expect(response['error']).to eq Barcoded::UNSUPPORTED_ENCODING
         end
       end
 
@@ -35,20 +35,21 @@ describe Barcoded do
         it 'will return 400 Bad Request' do
           post '/barcodes', barcode_request, headers
           expect(last_response.status).to eq 400
-          expect(json_response['error']).to eq Barcoded::INVALID_DATA
+          expect(response['error']).to eq Barcoded::INVALID_DATA
         end
       end
 
       it 'will return a 201 Created' do
         post '/barcodes', barcode_request, headers
         expect(last_response.status).to eq 201
-        expect(json_response['location']).to_not be_nil
+        expect(response['location']).to_not be_nil
       end
     end
 
     context 'with Content Type application/json' do
       it_behaves_like 'a supported content type' do
         let(:content_type) { 'application/json' }
+        let(:accept) { 'application/json' }
         let(:barcode_request) do
           { encoding: encoding, format: format, data: data }.to_json
         end
@@ -58,8 +59,29 @@ describe Barcoded do
     context 'with Content Type application/x-www-form-urlencoded' do
       it_behaves_like 'a supported content type' do
         let(:content_type) { 'application/x-www-form-urlencoded' }
+        let(:accept) { '*/*' }
         let(:barcode_request) do
           { encoding: encoding, format: format, data: data }
+        end
+      end
+    end
+
+    context 'with Content Type text/xml' do
+      it_behaves_like 'a supported content type' do
+        let(:content_type) { 'text/xml' }
+        let(:accept) { 'text/xml' }
+        let(:barcode_request) do
+          { encoding: encoding, format: format, data: data }.to_xml(:root => :barcode, :skip_types => true)
+        end
+      end
+    end
+
+    context 'with Content Type application/xml' do
+      it_behaves_like 'a supported content type' do
+        let(:content_type) { 'application/xml' }
+        let(:accept) { 'application/xml' }
+        let(:barcode_request) do
+          { encoding: encoding, format: format, data: data }.to_xml(:root => :barcode, :skip_types => true)
         end
       end
     end
@@ -77,7 +99,7 @@ describe Barcoded do
         it 'will return 400 Bad Request' do
           post '/barcodes', barcode_request
           expect(last_response.status).to eq 400
-          expect(json_response['error']).to eq Barcoded::MISSING_REQUIRED_PARAMS
+          expect(response['error']).to eq Barcoded::MISSING_REQUIRED_PARAMS
         end
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,7 +21,7 @@ Dir['./spec/support/**/*.rb'].each { |f| require f }
 
 RSpec.configure do |config|
   config.include Rack::Test::Methods
-  config.include JsonRequestHelper
+  config.include RequestHelper
   config.mock_framework = :rr
 
   def app

--- a/spec/support/json_request_helper.rb
+++ b/spec/support/json_request_helper.rb
@@ -1,5 +1,0 @@
-module JsonRequestHelper
-  def json_response 
-    JSON.parse(last_response.body)
-  end
-end

--- a/spec/support/request_helper.rb
+++ b/spec/support/request_helper.rb
@@ -1,0 +1,13 @@
+module RequestHelper
+  # If no accept header is supplied, default response is JSON
+  def response
+    case last_request.content_type
+      when 'application/json'
+        JSON.parse(last_response.body)
+      when 'application/xml', 'text/xml'
+        Hash.from_xml(last_response.body)['barcode']
+      else
+        JSON.parse(last_response.body)
+    end
+  end
+end


### PR DESCRIPTION
RFC @doomspork
This commit adds support for XML, there are a few talking points here and possibilities for refactoring, as well as a discussion on the value this may or may not add.

Right now it will look at the Accept HTTP header, if it is application/xml or text/xml it will respond accordingly. If Accept is application/json or _/_ (defaults to JSON) it will return JSON.

Additional note, when working with XML we need a root node. I used `<barcode>` , If we did consider this it might be wise to think about having JSON responses with a similarly named object?

In any case, :thumbsup: or :thumbsdown: either way, here it is.
