### PR TITLE
Added a root object to JSON response to match XML

### DIFF
--- a/lib/sinatra/response_helpers.rb
+++ b/lib/sinatra/response_helpers.rb
@@ -28,7 +28,7 @@ module Sinatra
       status 201
       data = params.merge(location)
       respond_to do |format|
-        format.json { data.to_json }
+        format.json { { barcode: data }.to_json }
         format.xml { data.to_xml(:root => :barcode, :skip_types => true) }
       end
     end
@@ -54,7 +54,7 @@ module Sinatra
     # Returns a Response with a code and body
     def do_halt(code, body)
       respond_to do |format|
-        format.json { halt code, body.to_json }
+        format.json { halt code, { barcode: body }.to_json }
         format.xml { halt code, body.to_xml(:root => :barcode, :skip_types => true) }
       end
     end

--- a/spec/support/request_helper.rb
+++ b/spec/support/request_helper.rb
@@ -2,12 +2,10 @@ module RequestHelper
   # If no accept header is supplied, default response is JSON
   def response
     case last_request.content_type
-      when 'application/json'
-        JSON.parse(last_response.body)
       when 'application/xml', 'text/xml'
         Hash.from_xml(last_response.body)['barcode']
       else
-        JSON.parse(last_response.body)
+        JSON.parse(last_response.body)['barcode']
     end
   end
 end


### PR DESCRIPTION
RCF @doomspork.

I know we talked about this briefly did you want to do this to make the XML and JSON responses similar.
I do think it is a bit odd returning the error wrapped in a root of `barcode` maybe we can change that to be wrapped in `error` ?
