### PR TITLE
Fix Rack::Lint exception

### DIFF
--- a/lib/sinatra/response_helpers.rb
+++ b/lib/sinatra/response_helpers.rb
@@ -65,7 +65,7 @@ module Sinatra
     #
     # Returns a Hash with `location` key
     def location
-      { location: resource_link }
+      { 'location' => resource_link }
     end
     
     # Internal: Build a resource link based on the requested data 


### PR DESCRIPTION
@doomspork

This was causing the following error

```
Rack::Lint::LintError: header key must be a string, was Symbol
/usr/local/ruby-2.1.1/lib/ruby/gems/2.1.0/gems/rack-1.5.2/lib/rack/lint.rb:20:in `assert'
/usr/local/ruby-2.1.1/lib/ruby/gems/2.1.0/gems/rack-1.5.2/lib/rack/lint.rb:570:in `block in check_headers'
/usr/local/ruby-2.1.1/lib/ruby/gems/2.1.0/gems/rack-1.5.2/lib/rack/utils.rb:451:in `block in each'
/usr/local/ruby-2.1.1/lib/ruby/gems/2.1.0/gems/rack-1.5.2/lib/rack/utils.rb:450:in `each'
/usr/local/ruby-2.1.1/lib/ruby/gems/2.1.0/gems/rack-1.5.2/lib/rack/utils.rb:450:in `each'
/usr/local/ruby-2.1.1/lib/ruby/gems/2.1.0/gems/rack-1.5.2/lib/rack/lint.rb:564:in `check_headers'
/usr/local/ruby-2.1.1/lib/ruby/gems/2.1.0/gems/rack-1.5.2/lib/rack/lint.rb:53:in `_call'
/usr/local/ruby-2.1.1/lib/ruby/gems/2.1.0/gems/rack-1.5.2/lib/rack/lint.rb:37:in `call'
/usr/local/ruby-2.1.1/lib/ruby/gems/2.1.0/gems/rack-1.5.2/lib/rack/showexceptions.rb:24:in `call'
/usr/local/ruby-2.1.1/lib/ruby/gems/2.1.0/gems/rack-1.5.2/lib/rack/commonlogger.rb:33:in `call'
/usr/local/ruby-2.1.1/lib/ruby/gems/2.1.0/gems/sinatra-1.4.5/lib/sinatra/base.rb:217:in `call'
/usr/local/ruby-2.1.1/lib/ruby/gems/2.1.0/gems/shotgun-0.9/lib/shotgun/loader.rb:86:in `proceed_as_child'
/usr/local/ruby-2.1.1/lib/ruby/gems/2.1.0/gems/shotgun-0.9/lib/shotgun/loader.rb:31:in `call!'
/usr/local/ruby-2.1.1/lib/ruby/gems/2.1.0/gems/shotgun-0.9/lib/shotgun/loader.rb:18:in `call'
/usr/local/ruby-2.1.1/lib/ruby/gems/2.1.0/gems/shotgun-0.9/lib/shotgun/favicon.rb:12:in `call'
/usr/local/ruby-2.1.1/lib/ruby/gems/2.1.0/gems/rack-1.5.2/lib/rack/builder.rb:138:in `call'
/usr/local/ruby-2.1.1/lib/ruby/gems/2.1.0/gems/rack-1.5.2/lib/rack/handler/webrick.rb:60:in `service'
/usr/local/ruby-2.1.1/lib/ruby/2.1.0/webrick/httpserver.rb:138:in `service'
/usr/local/ruby-2.1.1/lib/ruby/2.1.0/webrick/httpserver.rb:94:in `run'
/usr/local/ruby-2.1.1/lib/ruby/2.1.0/webrick/server.rb:295:in `block in start_thread'
```
