### PR TITLE
Support Code128 auto-detection

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'activesupport', '~> 4.1.1'
-gem 'barby'
+gem 'barby', '~> 0.6.1'
 gem 'builder', '~> 3.2.2'
 gem 'rmagick', '2.13.2', require: false
 gem 'rqrcode'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,7 +107,7 @@ PLATFORMS
 
 DEPENDENCIES
   activesupport (~> 4.1.1)
-  barby
+  barby (~> 0.6.1)
   builder (~> 3.2.2)
   coveralls
   icepick (~> 1.1.1)

--- a/barcoded.rb
+++ b/barcoded.rb
@@ -20,7 +20,7 @@ class Barcoded < Sinatra::Base
   end
 
   get '/img/*/*.*' do |encoding, data, format|
-    barcode = create_barcode(encoding, data)
+    barcode = create_barcode(encoding, URI.unescape(data))
     image   = BarcodeImageFactory.build(barcode, format)
     send_image image, format
   end

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,6 +1,7 @@
 require 'active_support'
 require 'active_support/core_ext/hash/conversions'
 require 'bundler/setup'
+require 'uri'
 require 'json'
 require 'sinatra/base'
 require 'sinatra/contrib'
@@ -12,5 +13,5 @@ ENV['RACK_CORS_ORIGINS']  ||= '*'
 
 Bundler.require(:default, ENV['RACK_ENV'])
 
-path = File.join(Dir.pwd, '{config/initializers,lib}', '**', '*.rb')
+path = File.join(Dir.pwd, '{config,lib}', '**', '*.rb')
 Dir[path].each { |file| require file }

--- a/lib/barcode_factory.rb
+++ b/lib/barcode_factory.rb
@@ -13,9 +13,7 @@ class BarcodeFactory
 
   ENCODINGS = {
     'bookland'          => 'Barby::Bookland',
-    'code128a'          => 'Barby::Code128A',
-    'code128b'          => 'Barby::Code128B',
-    'code128c'          => 'Barby::Code128C',
+    'code128'           => 'Barby::Code128',
     'code25'            => 'Barby::Code25',
     'code25interleaved' => 'Barby::Code25Interleaved',
     'code39'            => 'Barby::Code39',

--- a/lib/sinatra/response_helpers.rb
+++ b/lib/sinatra/response_helpers.rb
@@ -72,7 +72,7 @@ module Sinatra
     #
     # Returns a String
     def resource_link
-      "#{current_host}/img/#{encoding}/#{data}.#{format}"
+      URI.escape("#{current_host}/img/#{encoding}/#{data}.#{format}")
     end
 
     # Internal: Build a String for the current host

--- a/spec/lib/barcode_factory_spec.rb
+++ b/spec/lib/barcode_factory_spec.rb
@@ -16,26 +16,14 @@ describe BarcodeFactory do
 
     context 'with dash in symbology' do
       it_behaves_like 'a supported symbology' do
-        let(:symbology) { 'code-128a' }
+        let(:symbology) { 'code-128' }
       end
     end
 
-    context 'code-128A' do
+    context 'code-128' do
       it_behaves_like 'a supported symbology' do
-        let(:symbology) { 'code128a' }
-      end
-    end
-
-    context 'code-128B' do
-      it_behaves_like 'a supported symbology' do
-        let(:symbology) { 'code128b' }
-      end
-    end
-
-    context 'code-128C' do
-      it_behaves_like 'a supported symbology' do
-        let(:symbology) { 'code128c' }
-        let(:data)      { '00010203' }
+        let(:symbology) { 'code128' }
+        let(:data)      { 'ABC123' }
       end
     end
 


### PR DESCRIPTION
RFC @jamesbrink (and any interested parties) — This PR removes support for `code-128a`, `code-128b`, and `code-128c` in favor of `code-128` which handles auto-detection and supports multiple subsets within a single barcode.

This requires at least Barby 0.6.0.

In order to support for multiple subset barcodes I needed to add support for escaping/unescaping URIs, something we should have done originally — oops!
