### PR TITLE
Support height and xdim image options

### DIFF
--- a/barcoded.rb
+++ b/barcoded.rb
@@ -21,7 +21,7 @@ class Barcoded < Sinatra::Base
 
   get '/img/*/*.*' do |encoding, data, format|
     barcode = create_barcode(encoding, URI.unescape(data))
-    image   = BarcodeImageFactory.build(barcode, format)
+    image   = BarcodeImageFactory.build(barcode, format, options)
     send_image image, format
   end
 

--- a/lib/barcode_image_factory.rb
+++ b/lib/barcode_image_factory.rb
@@ -1,9 +1,9 @@
 class BarcodeImageFactory
 
-  def self.build(barcode, format)
+  def self.build(barcode, format, options = {})
     out       = format_outputter(format)
     outputter = out.new(barcode)
-    outputter.send("to_#{format}")
+    outputter.send("to_#{format}", options)
   end
 
   private

--- a/lib/sinatra/request_helpers.rb
+++ b/lib/sinatra/request_helpers.rb
@@ -21,6 +21,12 @@ module Sinatra
       (params['format'] || '').downcase
     end
 
+    SUPPORTED_OPTIONS = %w(height xdim)
+    def options
+      options = (params['options'] || params).slice(*SUPPORTED_OPTIONS).symbolize_keys
+      options.update(options) { |_, v, _| v.to_i }
+    end
+
     def normalize_params!
       case request.env['CONTENT_TYPE']
       when 'application/json'

--- a/lib/sinatra/response_helpers.rb
+++ b/lib/sinatra/response_helpers.rb
@@ -67,12 +67,13 @@ module Sinatra
     def location
       { 'location' => resource_link }
     end
-    
-    # Internal: Build a resource link based on the requested data 
+
+    # Internal: Build a resource link based on the requested data
     #
     # Returns a String
     def resource_link
-      URI.escape("#{current_host}/img/#{encoding}/#{data}.#{format}")
+      query = URI.encode_www_form(options)
+      URI.escape("#{current_host}/img/#{encoding}/#{data}.#{format}?#{query}")
     end
 
     # Internal: Build a String for the current host


### PR DESCRIPTION
RFC @jamesbrink — **DO NOT MERGE YET**

This is a quick shot at adding options to the image request such as `height` and `xdim`.  It should be noted that `height` is only applicable on 1D barcodes and `xdim` on 2D.  Furthermore, I'd like to determine a better name for `xdim` (what Barby refers to it as), any thoughts?
